### PR TITLE
[RESTEASY-2474] Get rid of Log4j v1

### DIFF
--- a/eagledns/pom.xml
+++ b/eagledns/pom.xml
@@ -21,8 +21,16 @@
             <version>2.0.8</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
         </dependency>
     </dependencies>
 

--- a/eagledns/src/main/java/se/unlogic/eagledns/CachedSecondaryZone.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/CachedSecondaryZone.java
@@ -1,15 +1,15 @@
 package se.unlogic.eagledns;
 
-import org.apache.log4j.Logger;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.jboss.logging.Logger;
 import org.xbill.DNS.DClass;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.Zone;
 import org.xbill.DNS.ZoneTransferException;
 import org.xbill.DNS.ZoneTransferIn;
-
-import java.io.IOException;
-import java.sql.Timestamp;
-import java.util.List;
 
 
 public class CachedSecondaryZone {

--- a/eagledns/src/main/java/se/unlogic/eagledns/EagleDNS.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/EagleDNS.java
@@ -1,35 +1,5 @@
 package se.unlogic.eagledns;
 
-import org.apache.log4j.Logger;
-import org.xbill.DNS.Address;
-import org.xbill.DNS.CNAMERecord;
-import org.xbill.DNS.DClass;
-import org.xbill.DNS.DNAMERecord;
-import org.xbill.DNS.ExtendedFlags;
-import org.xbill.DNS.Flags;
-import org.xbill.DNS.Header;
-import org.xbill.DNS.Message;
-import org.xbill.DNS.NSRecord;
-import org.xbill.DNS.Name;
-import org.xbill.DNS.NameTooLongException;
-import org.xbill.DNS.OPTRecord;
-import org.xbill.DNS.Opcode;
-import org.xbill.DNS.RRset;
-import org.xbill.DNS.Rcode;
-import org.xbill.DNS.Record;
-import org.xbill.DNS.Section;
-import org.xbill.DNS.SetResponse;
-import org.xbill.DNS.TSIG;
-import org.xbill.DNS.TSIGRecord;
-import org.xbill.DNS.Type;
-import org.xbill.DNS.Zone;
-import se.unlogic.standardutils.reflection.ReflectionUtils;
-import se.unlogic.standardutils.settings.SettingNode;
-import se.unlogic.standardutils.settings.XMLSettingNode;
-import se.unlogic.standardutils.string.StringUtils;
-import se.unlogic.standardutils.time.MillisecondTimeUnits;
-import se.unlogic.standardutils.timer.RunnableTimerTask;
-
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -59,6 +29,37 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import org.jboss.logging.Logger;
+import org.xbill.DNS.Address;
+import org.xbill.DNS.CNAMERecord;
+import org.xbill.DNS.DClass;
+import org.xbill.DNS.DNAMERecord;
+import org.xbill.DNS.ExtendedFlags;
+import org.xbill.DNS.Flags;
+import org.xbill.DNS.Header;
+import org.xbill.DNS.Message;
+import org.xbill.DNS.NSRecord;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.NameTooLongException;
+import org.xbill.DNS.OPTRecord;
+import org.xbill.DNS.Opcode;
+import org.xbill.DNS.RRset;
+import org.xbill.DNS.Rcode;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.Section;
+import org.xbill.DNS.SetResponse;
+import org.xbill.DNS.TSIG;
+import org.xbill.DNS.TSIGRecord;
+import org.xbill.DNS.Type;
+import org.xbill.DNS.Zone;
+
+import se.unlogic.standardutils.reflection.ReflectionUtils;
+import se.unlogic.standardutils.settings.SettingNode;
+import se.unlogic.standardutils.settings.XMLSettingNode;
+import se.unlogic.standardutils.string.StringUtils;
+import se.unlogic.standardutils.time.MillisecondTimeUnits;
+import se.unlogic.standardutils.timer.RunnableTimerTask;
 
 /**
  * EagleDNS copyright Robert "Unlogic" Olofsson (unlogic@unlogic.se)

--- a/eagledns/src/main/java/se/unlogic/eagledns/EagleManagerClient.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/EagleManagerClient.java
@@ -1,12 +1,13 @@
 package se.unlogic.eagledns;
 
-import org.apache.log4j.Logger;
-import se.unlogic.standardutils.settings.XMLSettingNode;
-
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
+
+import org.jboss.logging.Logger;
+
+import se.unlogic.standardutils.settings.XMLSettingNode;
 
 
 public class EagleManagerClient {

--- a/eagledns/src/main/java/se/unlogic/eagledns/LoginHandler.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/LoginHandler.java
@@ -1,9 +1,9 @@
 package se.unlogic.eagledns;
 
-import org.apache.log4j.Logger;
-
 import java.rmi.server.ServerNotActiveException;
 import java.rmi.server.UnicastRemoteObject;
+
+import org.jboss.logging.Logger;
 
 
 public class LoginHandler implements EagleLogin {

--- a/eagledns/src/main/java/se/unlogic/eagledns/TCPConnection.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/TCPConnection.java
@@ -1,13 +1,13 @@
 package se.unlogic.eagledns;
 
-import org.apache.log4j.Logger;
-import org.xbill.DNS.Message;
-
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
+
+import org.jboss.logging.Logger;
+import org.xbill.DNS.Message;
 
 
 public class TCPConnection implements Runnable {

--- a/eagledns/src/main/java/se/unlogic/eagledns/TCPSocketMonitor.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/TCPSocketMonitor.java
@@ -1,12 +1,12 @@
 package se.unlogic.eagledns;
 
-import org.apache.log4j.Logger;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+
+import org.jboss.logging.Logger;
 
 
 public class TCPSocketMonitor extends Thread {

--- a/eagledns/src/main/java/se/unlogic/eagledns/UDPConnection.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/UDPConnection.java
@@ -1,11 +1,11 @@
 package se.unlogic.eagledns;
 
-import org.apache.log4j.Logger;
-import org.xbill.DNS.Message;
-
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
+
+import org.jboss.logging.Logger;
+import org.xbill.DNS.Message;
 
 
 public class UDPConnection implements Runnable {

--- a/eagledns/src/main/java/se/unlogic/eagledns/UDPSocketMonitor.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/UDPSocketMonitor.java
@@ -1,12 +1,12 @@
 package se.unlogic.eagledns;
 
-import org.apache.log4j.Logger;
-
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
+
+import org.jboss.logging.Logger;
 
 
 public class UDPSocketMonitor extends Thread {

--- a/eagledns/src/main/java/se/unlogic/eagledns/test/ZoneDissasembler.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/test/ZoneDissasembler.java
@@ -1,13 +1,13 @@
 package se.unlogic.eagledns.test;
 
-import org.apache.log4j.Logger;
+import java.io.File;
+import java.io.IOException;
+
+import org.jboss.logging.Logger;
 import org.xbill.DNS.Master;
 import org.xbill.DNS.Name;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.TextParseException;
-
-import java.io.File;
-import java.io.IOException;
 
 
 public class ZoneDissasembler {

--- a/eagledns/src/main/java/se/unlogic/eagledns/utils/PrimaryZones2DB.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/utils/PrimaryZones2DB.java
@@ -1,7 +1,13 @@
 package se.unlogic.eagledns.utils;
 
-import org.apache.log4j.Logger;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.sql.DataSource;
+
+import org.jboss.logging.Logger;
 import org.xbill.DNS.Zone;
+
 import se.unlogic.eagledns.zoneproviders.db.beans.DBRecord;
 import se.unlogic.eagledns.zoneproviders.db.beans.DBZone;
 import se.unlogic.eagledns.zoneproviders.file.FileZoneProvider;
@@ -9,10 +15,6 @@ import se.unlogic.standardutils.dao.AnnotatedDAO;
 import se.unlogic.standardutils.dao.SimpleAnnotatedDAOFactory;
 import se.unlogic.standardutils.dao.SimpleDataSource;
 import se.unlogic.standardutils.dao.TransactionHandler;
-
-import javax.sql.DataSource;
-import java.util.ArrayList;
-import java.util.Collection;
 
 
 public class PrimaryZones2DB {

--- a/eagledns/src/main/java/se/unlogic/eagledns/zoneproviders/db/DBZoneProvider.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/zoneproviders/db/DBZoneProvider.java
@@ -1,7 +1,17 @@
 package se.unlogic.eagledns.zoneproviders.db;
 
-import org.apache.log4j.Logger;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.jboss.logging.Logger;
 import org.xbill.DNS.Zone;
+
 import se.unlogic.eagledns.SecondaryZone;
 import se.unlogic.eagledns.ZoneProvider;
 import se.unlogic.eagledns.zoneproviders.db.beans.DBRecord;
@@ -14,14 +24,6 @@ import se.unlogic.standardutils.dao.SimpleAnnotatedDAOFactory;
 import se.unlogic.standardutils.dao.SimpleDataSource;
 import se.unlogic.standardutils.dao.TransactionHandler;
 import se.unlogic.standardutils.reflection.ReflectionUtils;
-
-import javax.sql.DataSource;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 public class DBZoneProvider implements ZoneProvider {
 

--- a/eagledns/src/main/java/se/unlogic/eagledns/zoneproviders/file/FileZoneProvider.java
+++ b/eagledns/src/main/java/se/unlogic/eagledns/zoneproviders/file/FileZoneProvider.java
@@ -1,16 +1,5 @@
 package se.unlogic.eagledns.zoneproviders.file;
 
-import org.apache.log4j.Logger;
-import org.xbill.DNS.Name;
-import org.xbill.DNS.TextParseException;
-import org.xbill.DNS.Zone;
-import se.unlogic.eagledns.SecondaryZone;
-import se.unlogic.eagledns.ZoneChangeCallback;
-import se.unlogic.eagledns.ZoneProvider;
-import se.unlogic.eagledns.ZoneProviderUpdatable;
-import se.unlogic.standardutils.numbers.NumberUtils;
-import se.unlogic.standardutils.timer.RunnableTimerTask;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -18,6 +7,18 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Timer;
+
+import org.jboss.logging.Logger;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Zone;
+
+import se.unlogic.eagledns.SecondaryZone;
+import se.unlogic.eagledns.ZoneChangeCallback;
+import se.unlogic.eagledns.ZoneProvider;
+import se.unlogic.eagledns.ZoneProviderUpdatable;
+import se.unlogic.standardutils.numbers.NumberUtils;
+import se.unlogic.standardutils.timer.RunnableTimerTask;
 
 
 /**

--- a/eagledns/src/main/java/se/unlogic/standardutils/callback/SysoutCallback.java
+++ b/eagledns/src/main/java/se/unlogic/standardutils/callback/SysoutCallback.java
@@ -1,7 +1,6 @@
 package se.unlogic.standardutils.callback;
 
-
-import org.apache.log4j.Logger;
+import org.jboss.logging.Logger;
 
 public class SysoutCallback<T> implements Callback<T> {
 

--- a/eagledns/src/main/java/se/unlogic/standardutils/crypto/Base64.java
+++ b/eagledns/src/main/java/se/unlogic/standardutils/crypto/Base64.java
@@ -1,6 +1,6 @@
 package se.unlogic.standardutils.crypto;
 
-import org.apache.log4j.Logger;
+import org.jboss.logging.Logger;
 
 /**
  * <p>

--- a/eagledns/src/main/java/se/unlogic/standardutils/threads/ThreadPoolTaskGroupHandler.java
+++ b/eagledns/src/main/java/se/unlogic/standardutils/threads/ThreadPoolTaskGroupHandler.java
@@ -7,8 +7,6 @@
  ******************************************************************************/
 package se.unlogic.standardutils.threads;
 
-import org.apache.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -16,6 +14,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+
+import org.jboss.logging.Logger;
 
 
 

--- a/eagledns/src/main/java/se/unlogic/standardutils/xml/XMLUtils.java
+++ b/eagledns/src/main/java/se/unlogic/standardutils/xml/XMLUtils.java
@@ -7,12 +7,15 @@
  ******************************************************************************/
 package se.unlogic.standardutils.xml;
 
-import org.apache.log4j.Logger;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -26,15 +29,13 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.net.URI;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map.Entry;
+
+import org.jboss.logging.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 public class XMLUtils {
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-annotations>2.1.0.Final</version.org.jboss.logging.jboss-logging-annotations>
         <version.org.slf4j>1.7.25</version.org.slf4j>
-        <version.log4j>2.9.1</version.log4j>
     </properties>
 
     <url>https://resteasy.github.io/</url>
@@ -188,21 +187,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-nop</artifactId>
                 <version>${version.org.slf4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${version.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${version.log4j}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -16,11 +16,6 @@
 
     <dependencies>
         <dependency>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-          <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
Preliminary step for moving to Log4J 2 in main RESTEasy is getting rid of the Log4J v1 dependency that's coming transitively from the eagledns fork.