### PR TITLE
Migrate to the jakarta.ws.rs-api API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <!-- maven-surefire-plugin -->
         <surefire.system.args>-Xms512m -Xmx512m ${modular.jdk.args} ${modular.jdk.props}</surefire.system.args>
         <!-- Plugins versions -->
-        <version.javax.ws.rs-api>1.0.2.Final</version.javax.ws.rs-api>
+        <version.jakarta.ws.rs-api>2.1.6</version.jakarta.ws.rs-api>
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
         <version.org.jboss.logging.jboss-logging>3.4.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-annotations>2.2.1.Final</version.org.jboss.logging.jboss-logging-annotations>
@@ -156,9 +156,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.spec.javax.ws.rs</groupId>
-                <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-                <version>${version.javax.ws.rs-api}</version>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.ws.rs-api}</version>
             </dependency>
 
             <dependency>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -16,9 +16,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>${version.javax.ws.rs-api}</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
How do we feel about using the Jakarta Maven coordinates instead of the JBoss ones? I personally like the idea to make it obvious which version of the Jakarta RESTful Web Services we're targeting.